### PR TITLE
Moderator fix

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -30,7 +30,7 @@ export default {
         },
         body: JSON.stringify({ address, message, signature }),
       })).text();
-      window.location = `https://league.superhero.com/broadcast?jwt=${token}`;
+      window.location = `https://test.league.aeternity.org/broadcast?jwt=${token}`;
     },
   },
   async created() {

--- a/srv/index.js
+++ b/srv/index.js
@@ -66,14 +66,14 @@ export default (app, http) => {
         context: {
           user: {
             avatar: `https://robohash.org/${address}`,
-            name,
-            moderator: moderators.includes(name),
+            name
           }
         },
         aud: 'aeternity-jitsi',
         iss: 'jwt.z52da5wt.xyz',
         sub: 'jwt.z52da5wt.xyz',
-        room: '*'
+        room: '*',
+        moderator: moderators.includes(name)
       },
       process.env.VUE_APP_JWT_SECRET, {
         algorithm: 'HS256',


### PR DESCRIPTION
According to the plugin structure the moderator field is a "root" one, see https://github.com/nvonahsen/jitsi-token-moderation-plugin#usage

I also changed to test URL so that moderators can test this out in a safer way.


In general it would be nice to have that url as parameter (but in a secure way) somehow. Or at least have a deployment configuration option. No good propositions so far.