### PR TITLE
change name statement to the isArray instead of length

### DIFF
--- a/srv/index.js
+++ b/srv/index.js
@@ -69,7 +69,7 @@ export default (app, http) => {
     }
 
     const names = await (await middlewarePromise).api.getNameByAddress(address);
-    const name = names.length ? names[0].name : address;
+    const name = Array.isArray(names) ? names[0].name : address;
 
     const jwt = sign(
       {


### PR DESCRIPTION
Hello. I found that issue https://github.com/aeternity/jitsi-meet/issues/185
But as far as I can see this is at jwt-auth repo side.
The reason why I change `length` to the `isArray` that if user have only one chain name address will be returned.

Example:
```js
[].length ? 'names[0].name' : 'address';
// "address"
Array.isArray([]) ? 'names[0].name' : 'address';
// "names[0].name"
```